### PR TITLE
fix(dependency-review): comment summary only on failure

### DIFF
--- a/dependency-review/action.yml
+++ b/dependency-review/action.yml
@@ -6,7 +6,8 @@ runs:
     - name: 'Checkout Repository'
       uses: actions/checkout@1e31de5234b9f8995739874a8ce0492dc87873e2 # v4.0.0
     - name: 'Dependency Review'
-      uses: actions/dependency-review-action@cc4f6536e38d1126c5e3b0683d469a14f23bfea4 # v3
+      uses: actions/dependency-review-action@9129d7d40b8c12c1ed0f60400d00c92d437adcce # v4
       with:
         fail-on-severity: high
+        comment-summary-in-pr: on-failure
         allow-licenses: MIT,Apache-2.0,MPL-2.0,ISC,BSD-2-Clause,BSD-3-Clause,Unlicense,CC0-1.0,CC-BY-3.0,WTFPL,0BSD,AFL-2.1


### PR DESCRIPTION
This was adding a considerable amount of noise by commenting on every PR even on success (bug reported in https://github.com/actions/dependency-review-action/issues/697)